### PR TITLE
Update CODEOWNERS to facilitate x-team collaboration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be requested for review when someone opens a pull request.
-*       @ASFHyP3/maintainers
+*       @ASFHyP3/Tools @ASFHyP3/SciDev


### PR DESCRIPTION
Both Tools (S1 Orbits)  and SciDev (ITS_LIVE and HAND) currently manage AWS OpenData datasets. 

Notably, I do not expect or want to require approvals from both teams; this is just to facilitate communication. One approval from anyone on either of these three teams should generally be sufficient.

Parent tracking issue is here: https://github.com/ASFHyP3/.github-private/issues/7