### PR TITLE
add custom template for asf-event-data bucket

### DIFF
--- a/asf-event-data/bucket-cf.yml
+++ b/asf-event-data/bucket-cf.yml
@@ -13,7 +13,7 @@ Parameters:
     MinLength: '1'
     Type: String
 
-  OverviewAccountId:
+  OverviewAccountIds:
     Description: AWS account ID(s) that need permission to publish files to image-service-overviews/
     Type: CommaDelimitedList
 
@@ -108,9 +108,10 @@ Resources:
           - !Sub arn:aws:s3:::${DataSetBucket}/*
           - !Sub arn:aws:s3:::${DataSetBucket}
         - Action: s3:PutObject
+          Effect: Allow
           Principal:
-            AWS: !Ref AccountId
-          Resource: arn:aws:s3:::${DataSetBucket}/image-service-overviews/*
+            AWS: !Ref OverviewAccountIds
+          Resource: !Sub arn:aws:s3:::${DataSetBucket}/image-service-overviews/*
     Type: AWS::S3::BucketPolicy
 
 Outputs:

--- a/asf-event-data/bucket-cf.yml
+++ b/asf-event-data/bucket-cf.yml
@@ -1,5 +1,5 @@
 # customized version of the docs/pds-bucket-cf.yml template for creating the asf-event-data bucket
-# includes a bucket policy allowing s3:PutObject permissions to `s3://asf-event-data/image-service-overviews/` from the given AWS account
+# includes a bucket policy allowing s3:PutObject permissions to `s3://asf-event-data/image-service-overviews/` from the given AWS account(s)
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 Description: This template creates the AWS infrastructure to publish a public data set on S3. It creates a publicly-accessible S3 bucket for the dataset, enables CloudWatch Metrics for the dataset bucket, and creates a public SQS and Lambda subscribable SNS Topic.

--- a/asf-event-data/bucket-cf.yml
+++ b/asf-event-data/bucket-cf.yml
@@ -1,0 +1,122 @@
+# customized version of the docs/pds-bucket-cf.yml template for creating the asf-event-data bucket
+# includes a bucket policy allowing s3:PutObject permissions to `s3://asf-event-data/image-service-overviews/` from the given AWS account
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This template creates the AWS infrastructure to publish a public data set on S3. It creates a publicly-accessible S3 bucket for the dataset, enables CloudWatch Metrics for the dataset bucket, and creates a public SQS and Lambda subscribable SNS Topic.
+
+Parameters:
+  DataSetName:
+    AllowedPattern: "[a-z0-9\\.\\-]*"
+    ConstraintDescription: may only contain lowercase letters, numbers, and ., or - characters
+    Description: "The name of the dataset's S3 bucket. This will be used to create the dataset S3 bucket."
+    MaxLength: '250'
+    MinLength: '1'
+    Type: String
+
+  OverviewAccountId:
+    Description: AWS account ID(s) that need permission to publish files to image-service-overviews/
+    Type: CommaDelimitedList
+
+Resources:
+  SNSTopic:
+    Properties:
+      TopicName: !Join [ "", [ !Join [ "", !Split [ ".", !Ref DataSetName ] ], "-object_created" ] ]
+    Type: AWS::SNS::Topic
+  SNSTopicPolicy:
+    Properties:
+      Topics:
+        - !Ref SNSTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: allowS3BucketToPublish
+          Effect: Allow
+          Action:
+            - sns:Publish
+          Resource: !Ref SNSTopic
+          Principal:
+            Service: s3.amazonaws.com
+          Condition:
+            ArnLike:
+              aws:SourceArn: !Sub arn:aws:s3:::${DataSetName}
+        - Sid: allowOnlySQSandLambdaSubscription
+          Effect: Allow
+          Action:
+            - sns:Subscribe
+            - sns:Receive
+          Resource: !Ref SNSTopic
+          Principal:
+            AWS: "*"
+          Condition:
+            StringEquals:
+              SNS:Protocol:
+                - sqs
+                - lambda
+    Type: AWS::SNS::TopicPolicy
+  DataSetBucket:
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Delete
+    DependsOn:
+      - SNSTopicPolicy
+    Properties:
+      BucketName: !Ref DataSetName
+      MetricsConfigurations:
+        - Id: EntireBucket
+      LifecycleConfiguration:
+        Rules:
+        - Id: IntelligentTieringRule
+          Status: Enabled
+          Transitions:
+            - TransitionInDays: '0'
+              StorageClass: INTELLIGENT_TIERING
+        - Id: AbortIncompleteMultipartUploadRule
+          Status: Enabled
+          AbortIncompleteMultipartUpload:
+            DaysAfterInitiation: 7
+      NotificationConfiguration:
+        TopicConfigurations:
+        - Event: "s3:ObjectCreated:*"
+          Topic: !Ref SNSTopic
+      PublicAccessBlockConfiguration:
+          BlockPublicPolicy: false
+          RestrictPublicBuckets: false
+      CorsConfiguration:
+        CorsRules:
+        - AllowedHeaders:
+            - "*"
+          AllowedMethods:
+            - HEAD
+            - GET
+          AllowedOrigins:
+            - "*"
+          ExposedHeaders:
+            - ETag
+            - x-amz-meta-custom-header
+          MaxAge: 3000
+    Type: AWS::S3::Bucket
+  DataSetBucketPolicy:
+    Properties:
+      Bucket: !Ref DataSetBucket
+      PolicyDocument:
+        Statement:
+        - Action:
+          - s3:List*
+          - s3:Get*
+          Effect: Allow
+          Principal: "*"
+          Resource:
+          - !Sub arn:aws:s3:::${DataSetBucket}/*
+          - !Sub arn:aws:s3:::${DataSetBucket}
+        - Action: s3:PutObject
+          Principal:
+            AWS: !Ref AccountId
+          Resource: arn:aws:s3:::${DataSetBucket}/image-service-overviews/*
+    Type: AWS::S3::BucketPolicy
+
+Outputs:
+  DataBucket:
+    Description: "S3 data bucket name"
+    Value: !Sub ${DataSetBucket}
+  SNSTopic:
+    Description: "SQS and Lambda subscribable SNS Topic"
+    Value: !Ref SNSTopic


### PR DESCRIPTION
Here's the diff between the custom template and base template, for convenience:
```
$ diff asf-event-data/bucket-cf.yml docs/pds-bucket-cf.yml 
1,2d0
< # customized version of the docs/pds-bucket-cf.yml template for creating the asf-event-data bucket
< # includes a bucket policy allowing s3:PutObject permissions to `s3://asf-event-data/image-service-overviews/` from the given AWS account(s)
16,19d13
<   OverviewAccountIds:
<     Description: AWS account ID(s) that need permission to publish files to image-service-overviews/
<     Type: CommaDelimitedList
< 
110,114d103
<         - Action: s3:PutObject
<           Effect: Allow
<           Principal:
<             AWS: !Ref OverviewAccountIds
<           Resource: !Sub arn:aws:s3:::${DataSetBucket}/image-service-overviews/*
```